### PR TITLE
build: use `workspace` system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = [
+    "bootx64"
+]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BOOTX64_SRC_DIR	=	bootx64
 BOOTX64_SRCS	=	$(shell find $(BOOTX64_SRC_DIR) -name *.rs)
 BOOTX64_SRCS 	+=	$(BOOTX64_SRC_DIR)/Cargo.toml
 BOOTX64_SRCS	+=	$(BOOTX64_SRC_DIR)/.cargo/config.toml
-BOOTX64_DLL	=	$(BOOTX64_SRC_DIR)/target/$(ARCH)-pc-windows-gnu/debug/bootx64.dll
+BOOTX64_DLL	=	target/$(ARCH)-pc-windows-gnu/debug/bootx64.dll
 BOOTX64	=	$(BUILD_DIR)/bootx64.efi
 
 ISO_FILE	=	$(BUILD_DIR)/antei.iso

--- a/bootx64/Cargo.toml
+++ b/bootx64/Cargo.toml
@@ -8,12 +8,6 @@ edition = "2018"
 name = "bootx64"
 crate_type = ["cdylib"]
 
-[profile.dev]
-panic = "abort"
-
-[profile.release]
-panic = "abort"
-
 [dependencies]
 r-efi = "3.2.0"
 rlibc = "1.0.0"


### PR DESCRIPTION
This may reduce the time to compile. This also may enable to use
`clippy-check` action.
