### PR TITLE
chore: implement `uefi_global` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "bootloader/bootx64",
     "bootloader/uefi_wrapper",
+    "bootloader/uefi_global",
 ]
 
 [profile.dev]

--- a/bootloader/uefi_global/Cargo.toml
+++ b/bootloader/uefi_global/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "uefi_global"
+version = "0.1.0"
+authors = ["Hiroki Tokunaga <tokusan441@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/bootloader/uefi_global/src/lib.rs
+++ b/bootloader/uefi_global/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
This crate will contain global logger, allocator, and functions.