### PR TITLE
refactor(bootx64): give a default parameter

### DIFF
--- a/bootx64/src/allocator.rs
+++ b/bootx64/src/allocator.rs
@@ -1,6 +1,6 @@
 use {
+    crate::NumOfPages,
     core::convert::{TryFrom, TryInto},
-    os_units::NumOfPages,
     uefi_wrapper::service::boot::{MemoryDescriptor, CONVENTIONAL_MEMORY},
     x86_64::{
         structures::paging::{FrameAllocator, PhysFrame, Size4KiB},
@@ -16,7 +16,7 @@ impl<'a> Allocator<'a> {
         Self { mmap }
     }
 
-    fn allocate_frames(&mut self, n: NumOfPages<Size4KiB>) -> Option<PhysAddr> {
+    fn allocate_frames(&mut self, n: NumOfPages) -> Option<PhysAddr> {
         self.iter_mut_conventional()
             .find_map(|d| Self::try_alloc_from(d, n))
     }
@@ -25,11 +25,11 @@ impl<'a> Allocator<'a> {
         self.mmap.iter_mut().filter(|d| is_usable_memory(d))
     }
 
-    fn try_alloc_from(d: &mut MemoryDescriptor, n: NumOfPages<Size4KiB>) -> Option<PhysAddr> {
+    fn try_alloc_from(d: &mut MemoryDescriptor, n: NumOfPages) -> Option<PhysAddr> {
         is_enough_memory(d, n).then(|| Self::alloc_from(d, n))
     }
 
-    fn alloc_from(d: &mut MemoryDescriptor, num_pages: NumOfPages<Size4KiB>) -> PhysAddr {
+    fn alloc_from(d: &mut MemoryDescriptor, num_pages: NumOfPages) -> PhysAddr {
         let bytes = num_pages.as_bytes();
         let bytes: u64 = bytes.as_usize().try_into().unwrap();
 
@@ -56,6 +56,6 @@ fn is_usable_memory(d: &MemoryDescriptor) -> bool {
     d.r#type == CONVENTIONAL_MEMORY
 }
 
-fn is_enough_memory(d: &MemoryDescriptor, n: NumOfPages<Size4KiB>) -> bool {
+fn is_enough_memory(d: &MemoryDescriptor, n: NumOfPages) -> bool {
     d.number_of_pages >= u64::try_from(n.as_usize()).unwrap()
 }

--- a/bootx64/src/lib.rs
+++ b/bootx64/src/lib.rs
@@ -15,6 +15,10 @@ pub mod paging;
 pub mod panic;
 pub mod system_table;
 
+pub(crate) type NumOfPages<T = Size4KiB> = os_units::NumOfPages<T>;
+
+use x86_64::structures::paging::Size4KiB;
+
 pub(crate) use allocator::Allocator;
 pub use exit_boot_services::exit_boot_services_and_return_mmap;
 pub(crate) use mapper::Mapper;

--- a/bootx64/src/mapper.rs
+++ b/bootx64/src/mapper.rs
@@ -1,12 +1,14 @@
-use crate::Allocator;
-use aligned_ptr::ptr;
-use os_units::NumOfPages;
-use x86_64::structures::paging::PhysFrame;
-use x86_64::structures::paging::RecursivePageTable;
-use x86_64::structures::paging::Size4KiB;
-use x86_64::structures::paging::{FrameAllocator, PageTableFlags};
-use x86_64::structures::paging::{Mapper as MapperTrait, Page};
-use x86_64::VirtAddr;
+use {
+    crate::{Allocator, NumOfPages},
+    aligned_ptr::ptr,
+    x86_64::{
+        structures::paging::{
+            FrameAllocator, Mapper as MapperTrait, Page, PageTableFlags, PhysFrame,
+            RecursivePageTable, Size4KiB,
+        },
+        VirtAddr,
+    },
+};
 
 const RECURSIVE_PAGING: VirtAddr = VirtAddr::new_truncate(0xffff_ff7f_bfdf_e000);
 
@@ -36,7 +38,7 @@ impl<'a> Mapper<'a> {
     pub(crate) unsafe fn map_range_to_unused(
         &mut self,
         v: VirtAddr,
-        n: NumOfPages<Size4KiB>,
+        n: NumOfPages,
         flags: PageTableFlags,
     ) {
         for i in 0..n.as_usize() {
@@ -52,7 +54,7 @@ impl<'a> Mapper<'a> {
     pub(crate) unsafe fn update_flags_for_range(
         &mut self,
         v: VirtAddr,
-        n: NumOfPages<Size4KiB>,
+        n: NumOfPages,
         flags: PageTableFlags,
     ) {
         for i in 0..n.as_usize() {


### PR DESCRIPTION
Giving a default generic parameter `T = Size4KiB` should not cause a problem because there is no plan to use other page sizes.
