### PR TITLE
fix(Mmap): remove `as_slice_mut`

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -22,7 +22,7 @@ unsafe extern "sysv64" fn main(boot_info: *mut BootInfo) {
     let mut boot_info = unsafe { ptr::get(boot_info) };
     boot_info.validate();
 
-    mem::phys::init(boot_info.mmap_mut().as_slice_mut());
+    mem::phys::init(boot_info.mmap().as_slice());
 
     // SAFETY: The recursive address is accessible and there are no references to the current
     // working PML4.

--- a/libs/boot_info/src/lib.rs
+++ b/libs/boot_info/src/lib.rs
@@ -44,13 +44,13 @@ impl BootInfo {
         self.mmap.vaildate();
     }
 
+    pub fn mmap(&mut self) -> &Mmap {
+        &self.mmap
+    }
+
     fn check_header_and_footer(&self) {
         self.check_header();
         self.check_footer();
-    }
-
-    pub fn mmap(&mut self) -> &Mmap {
-        &self.mmap
     }
 
     fn check_header(&self) {

--- a/libs/boot_info/src/lib.rs
+++ b/libs/boot_info/src/lib.rs
@@ -84,6 +84,7 @@ impl Mmap {
         Self { start, len }
     }
 
+    #[must_use]
     pub fn as_slice(&self) -> &[MemoryDescriptor] {
         // SAFETY: `Mmap::new` ensures the safety.
         unsafe { slice::from_raw_parts(self.start.as_ptr(), self.len) }

--- a/libs/boot_info/src/lib.rs
+++ b/libs/boot_info/src/lib.rs
@@ -49,8 +49,8 @@ impl BootInfo {
         self.check_footer();
     }
 
-    pub fn mmap_mut(&mut self) -> &mut Mmap {
-        &mut self.mmap
+    pub fn mmap(&mut self) -> &Mmap {
+        &self.mmap
     }
 
     fn check_header(&self) {
@@ -84,12 +84,7 @@ impl Mmap {
         Self { start, len }
     }
 
-    pub fn as_slice_mut(&mut self) -> &mut [MemoryDescriptor] {
-        // SAFETY: `Mmap::new` ensures the safety.
-        unsafe { slice::from_raw_parts_mut(self.start.as_mut_ptr(), self.len) }
-    }
-
-    fn as_slice(&self) -> &[MemoryDescriptor] {
+    pub fn as_slice(&self) -> &[MemoryDescriptor] {
         // SAFETY: `Mmap::new` ensures the safety.
         unsafe { slice::from_raw_parts(self.start.as_ptr(), self.len) }
     }


### PR DESCRIPTION
This method can create multiple mutable references to the memory map because `Mmap` implements `Copy` and `Clone`. Mutability is not necessary so that we can delete the method.
