### PR TITLE
chore(kernel_mmap): define `TIMER`

### DIFF
--- a/libs/kernel_mmap/src/lib.rs
+++ b/libs/kernel_mmap/src/lib.rs
@@ -55,7 +55,11 @@ pub const KERNEL: Region = Region::new(
 #[allow(clippy::cast_possible_truncation)]
 pub const STACK: Region = Region::next_to(&KERNEL, Bytes::new(4 * Size4KiB::SIZE as usize));
 
+#[allow(clippy::cast_possible_truncation)]
+pub const TIMER: Region = Region::next_to(&STACK, Bytes::new(64 * Size4KiB::SIZE as usize));
+
 const_assert!(!KERNEL.overlaps_with(&STACK));
+const_assert!(!STACK.overlaps_with(&TIMER));
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This is the DMA memory buffer for timer.
