### PR TITLE
chore(frame_manager): use `PhysFrameRange`

### DIFF
--- a/kernel/src/mem/phys.rs
+++ b/kernel/src/mem/phys.rs
@@ -24,7 +24,11 @@ pub(super) fn frame_allocator<'a>() -> SpinlockGuard<'a, FrameAllocator<Size4KiB
 
 #[cfg(test_on_qemu)]
 mod tests {
-    use {super::frame_allocator, crate::NumOfPages, x86_64::PhysAddr};
+    use {
+        super::frame_allocator,
+        crate::NumOfPages,
+        x86_64::structures::paging::frame::{PhysFrame, PhysFrameRange},
+    };
 
     pub(super) fn main() {
         allocate_single_page_and_dealloc();
@@ -34,15 +38,15 @@ mod tests {
         let p = alloc(NumOfPages::new(1));
         let p = p.expect("Failed to allocate a page.");
 
-        dealloc(p);
+        dealloc(p.start);
     }
 
     #[must_use]
-    fn alloc(n: NumOfPages) -> Option<PhysAddr> {
+    fn alloc(n: NumOfPages) -> Option<PhysFrameRange> {
         frame_allocator().alloc(n)
     }
 
-    fn dealloc(a: PhysAddr) {
-        frame_allocator().dealloc(a)
+    fn dealloc(f: PhysFrame) {
+        frame_allocator().dealloc(f)
     }
 }

--- a/libs/frame_allocator/src/lib.rs
+++ b/libs/frame_allocator/src/lib.rs
@@ -273,6 +273,15 @@ mod tests {
         };
     }
 
+    macro_rules! phys_frame_range {
+        ($start:expr => $end:expr) => {
+            PhysFrameRange {
+                start: PhysFrame::from_start_address(PhysAddr::new($start)).unwrap(),
+                end: PhysFrame::from_start_address(PhysAddr::new($end)).unwrap(),
+            }
+        };
+    }
+
     #[test]
     fn fail_to_allocate() {
         let mut f = allocator!(
@@ -297,12 +306,7 @@ mod tests {
 
         let a = f.alloc(NumOfPages::new(3));
 
-        let expected = PhysFrameRange {
-            start: PhysFrame::from_start_address(PhysAddr::new(0x2000)).unwrap(),
-            end: PhysFrame::from_start_address(PhysAddr::new(0x5000)).unwrap(),
-        };
-
-        assert_eq!(a, Some(expected));
+        assert_eq!(a, Some(phys_frame_range!(0x2000 => 0x5000)));
         assert_eq!(
             f,
             allocator!(
@@ -319,12 +323,7 @@ mod tests {
         let mut f = allocator!(A 0 => 0x3000);
         let a = f.alloc(NumOfPages::new(3));
 
-        let expected = PhysFrameRange {
-            start: PhysFrame::from_start_address(PhysAddr::zero()).unwrap(),
-            end: PhysFrame::from_start_address(PhysAddr::new(0x3000)).unwrap(),
-        };
-
-        assert_eq!(a, Some(expected));
+        assert_eq!(a, Some(phys_frame_range!(0 => 0x3000)));
         assert_eq!(f, allocator!(U 0 => 0x3000));
     }
 


### PR DESCRIPTION
This ensures that the physical range is page-aligned.
