### PR TITLE
chore(bootx64): use the small code model

### DIFF
--- a/bootx64/.cargo/config.toml
+++ b/bootx64/.cargo/config.toml
@@ -4,7 +4,6 @@ target = "x86_64-pc-windows-gnu"
 [target.x86_64-pc-windows-gnu]
 rustflags = [
     "-C", "link-args=/nologo /nxcompat /nodefaultlib /entry:efi_main /subsystem:efi_application",
-    "-C", "code-model=large",
     "-C", "prefer-dynamic=n",
     "-C", "no-redzone=y",
     "-C", "panic=abort",


### PR DESCRIPTION
There is no need to use the large code model. See: https://github.com/rust-lang/rust/pull/87124
