### PR TITLE
ci: disable `disjoint_capture_migration` lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 5
 
     env:
-      RUSTFLAGS: -D warnings -D absolute_paths_not_starting_with_crate -D disjoint_capture_migration -D elided_lifetimes_in_paths -D explicit_outlives_requirements -D macro_use_extern_crate -D meta_variable_misuse -D missing_abi -D missing_copy_implementations -D missing_debug_implementations -D non_ascii_idents -D pointer_structural_match -D semicolon_in_expressions_from_macros -D single_use_lifetimes -D trivial_casts -D trivial_numeric_casts -D unaligned_references -D unreachable_pub -D unused_extern_crates -D unused_import_braces -D unused_lifetimes -D unused_qualifications
+      RUSTFLAGS: -D warnings -D absolute_paths_not_starting_with_crate -D elided_lifetimes_in_paths -D explicit_outlives_requirements -D macro_use_extern_crate -D meta_variable_misuse -D missing_abi -D missing_copy_implementations -D missing_debug_implementations -D non_ascii_idents -D pointer_structural_match -D semicolon_in_expressions_from_macros -D single_use_lifetimes -D trivial_casts -D trivial_numeric_casts -D unaligned_references -D unreachable_pub -D unused_extern_crates -D unused_import_braces -D unused_lifetimes -D unused_qualifications
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I don't use the feature.
