### PR TITLE
chore(kernel): use `fxsave` and `fxrstor`

### DIFF
--- a/kernel/src/asm.s
+++ b/kernel/src/asm.s
@@ -3,50 +3,6 @@
     .intel_syntax noprefix
 
 
-    .macro pushxmm
-
-    sub rsp, 16*16
-    movdqu [rsp+16*0], xmm0
-    movdqu [rsp+16*1], xmm1
-    movdqu [rsp+16*2], xmm2
-    movdqu [rsp+16*3], xmm3
-    movdqu [rsp+16*4], xmm4
-    movdqu [rsp+16*5], xmm5
-    movdqu [rsp+16*6], xmm6
-    movdqu [rsp+16*7], xmm7
-    movdqu [rsp+16*8], xmm8
-    movdqu [rsp+16*9], xmm9
-    movdqu [rsp+16*10], xmm10
-    movdqu [rsp+16*11], xmm11
-    movdqu [rsp+16*12], xmm12
-    movdqu [rsp+16*13], xmm13
-    movdqu [rsp+16*14], xmm14
-    movdqu [rsp+16*15], xmm15
-
-    .endm
-
-    .macro popxmm
-
-    movdqu xmm15, [rsp+16*15]
-    movdqu xmm14, [rsp+16*14]
-    movdqu xmm13, [rsp+16*13]
-    movdqu xmm12, [rsp+16*12]
-    movdqu xmm11, [rsp+16*11]
-    movdqu xmm10, [rsp+16*10]
-    movdqu xmm9, [rsp+16*9]
-    movdqu xmm8, [rsp+16*8]
-    movdqu xmm7, [rsp+16*7]
-    movdqu xmm6, [rsp+16*6]
-    movdqu xmm5, [rsp+16*5]
-    movdqu xmm4, [rsp+16*4]
-    movdqu xmm3, [rsp+16*3]
-    movdqu xmm2, [rsp+16*2]
-    movdqu xmm1, [rsp+16*1]
-    movdqu xmm0, [rsp+16*0]
-    add rsp, 16*16
-
-    .endm
-
     .macro handler vector
     .extern interrupt_handler_\vector
     .global asm_interrupt_handler_\vector
@@ -64,11 +20,17 @@ asm_interrupt_handler_\vector:
     push r10
     push r11
 
-    pushxmm
+    // `fxsave` saves 512-byte data, and it requires a 16-byte aligned address.
+    // After the `call` instruction, `rsp mod 16` is 8, so we add `8` here.
+    sub rsp, 512+8
+
+    fxsave [rsp]
 
     call interrupt_handler_\vector
 
-    popxmm
+    fxrstor [rsp]
+
+    add rsp, 512+8
 
     pop r11
     pop r10


### PR DESCRIPTION
This commit replaces `pushxmm` and `popxmm` macros with `fxsave` and
`fxrstor` instructions, reducing the number of lines and saving other
registers that the compiler may use in the future, such as mm registers.
