### PR TITLE
fix: avoid deadlocks

### DIFF
--- a/kernel/src/interrupt/mod.rs
+++ b/kernel/src/interrupt/mod.rs
@@ -1,2 +1,20 @@
 mod handler;
 pub(super) mod idt;
+
+use x86_64::instructions::interrupts;
+
+pub(crate) fn disable_interrupts_and_do<T>(f: impl FnOnce() -> T) -> T {
+    let interrupts_enabled = interrupts::are_enabled();
+
+    if interrupts_enabled {
+        interrupts::disable();
+    }
+
+    let r = f();
+
+    if interrupts_enabled {
+        interrupts::enable();
+    }
+
+    r
+}

--- a/kernel/src/io.rs
+++ b/kernel/src/io.rs
@@ -1,0 +1,13 @@
+// `qemu_println!` locks the serial port it uses. When a process switch occurs while sending a
+// string to the serial port, the port is not unlocked. If another process tries to print something
+// while the interrupts are disabled (e.g., for the debug of process switch), it fails to lock the
+// port because it has been already locked by the preceding process, so a deadlock happens. To
+// avoid this, `qemu_printlnk` firstly disables interrupts, then prints a string. We cannot
+// override `qemu_println` because of the name resolution.
+macro_rules! qemu_printlnk {
+    ($($arg:tt)*) => {
+        $crate::interrupt::disable_interrupts_and_do(||{
+            qemu_print::qemu_println!($($arg)*);
+        });
+    };
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,6 +5,8 @@ extern crate rlibc as _;
 
 mod gdt;
 mod interrupt;
+#[macro_use]
+mod io;
 mod libc;
 mod log;
 mod process;
@@ -14,7 +16,7 @@ mod tests;
 mod timer;
 mod tss;
 
-use {boot_info::BootInfo, core::panic::PanicInfo, interrupt::idt, qemu_print::qemu_println};
+use {boot_info::BootInfo, core::panic::PanicInfo, interrupt::idt};
 
 pub fn init(boot_info: BootInfo) {
     // SAFETY: `boot_info` is the pointer passed from the bootloader. w
@@ -52,7 +54,7 @@ pub fn idle() -> ! {
 fn panic(i: &PanicInfo<'_>) -> ! {
     x86_64::instructions::interrupts::disable();
 
-    qemu_println!("{}", i);
+    qemu_printlnk!("{}", i);
 
     exit_panic();
 }

--- a/kernel/src/log.rs
+++ b/kernel/src/log.rs
@@ -1,7 +1,4 @@
-use {
-    log::{set_logger, Level, LevelFilter, Log, Metadata, Record},
-    qemu_print::qemu_println,
-};
+use log::{set_logger, Level, LevelFilter, Log, Metadata, Record};
 
 static LOGGER: Logger = Logger;
 
@@ -21,9 +18,9 @@ impl Log for Logger {
     fn log(&self, record: &Record<'_>) {
         if self.enabled(record.metadata()) {
             if let (Some(file), Some(line)) = (record.file(), record.line()) {
-                qemu_println!("[{}:{}] {} - {}", file, line, record.level(), record.args());
+                qemu_printlnk!("[{}:{}] {} - {}", file, line, record.level(), record.args());
             } else {
-                qemu_println!("{} - {}", record.level(), record.args());
+                qemu_printlnk!("{} - {}", record.level(), record.args());
             }
         }
     }
@@ -31,7 +28,7 @@ impl Log for Logger {
     #[cfg(not(test_on_qemu))]
     fn log(&self, record: &Record<'_>) {
         if self.enabled(record.metadata()) {
-            qemu_println!("{} - {}", record.level(), record.args());
+            qemu_printlnk!("{} - {}", record.level(), record.args());
         }
     }
 

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -29,12 +29,26 @@ pub(crate) fn switch() {
 }
 
 pub(crate) fn send(to: Pid, message: Message) {
+    // The kernel-privileged processes call this function directly, so at this point, the
+    // interrupts may not be disabled. If a process switch occurs during the execution of this
+    // function because of the timer interrupt, the kernel-privileged process still locks the
+    // process manager. When the following process tries to switch, it fails to lock the process
+    // manager because the preceding kernel-privileged process has already locked it. That is why
+    // we disable interrupts while sending a message to avoid a process switch during the execution
+    // of this function.
     interrupt::disable_interrupts_and_do(|| {
         send_without_disabling_interrupts(to, message);
     })
 }
 
 pub(crate) fn receive(from: ReceiveFrom, buffer: *mut Message) {
+    // The kernel-privileged processes call this function directly, so at this point, the
+    // interrupts may not be disabled. If a process switch occurs during the execution of this
+    // function because of the timer interrupt, the kernel-privileged process still locks the
+    // process manager. When the following process tries to switch, it fails to lock the process
+    // manager because the preceding kernel-privileged process has already locked it. That is why
+    // we disable interrupts while receiving a message to avoid a process switch during the
+    // execution of this function.
     interrupt::disable_interrupts_and_do(|| {
         receive_without_disabling_interrupts(from, buffer);
     })

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -38,7 +38,7 @@ pub(crate) fn send(to: Pid, message: Message) {
     // of this function.
     interrupt::disable_interrupts_and_do(|| {
         send_without_disabling_interrupts(to, message);
-    })
+    });
 }
 
 pub(crate) fn receive(from: ReceiveFrom, buffer: *mut Message) {
@@ -51,7 +51,7 @@ pub(crate) fn receive(from: ReceiveFrom, buffer: *mut Message) {
     // execution of this function.
     interrupt::disable_interrupts_and_do(|| {
         receive_without_disabling_interrupts(from, buffer);
-    })
+    });
 }
 
 pub(super) fn init() {

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -128,8 +128,6 @@ impl Process {
 
                 let stack_range = vm::alloc_pages(stack_size, stack_flags)?;
 
-                log::info!("Stack range: {:?}", stack_range);
-
                 let context = Context::user(entry, pml4, stack_range.end.start_address());
                 let context = UnsafeCell::new(context);
 

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -128,6 +128,8 @@ impl Process {
 
                 let stack_range = vm::alloc_pages(stack_size, stack_flags)?;
 
+                log::info!("Stack range: {:?}", stack_range);
+
                 let context = Context::user(entry, pml4, stack_range.end.start_address());
                 let context = UnsafeCell::new(context);
 


### PR DESCRIPTION
This commit removes the cause of the deadlock caused by IPC. When a
kernel-privileged process calls `send` or `receive`, the interrupts are
still enabled. If the timer interrupt happens during the executions of
these functions, a process switch occurs with the process manager
locked. Then, if another process (either kernel or user privileged)
calls an IPC function, it fails to lock the process manager because
the preceding kernel-privileged process has already locked it. This
commit changes `send` and `receive` so that these functions disable
interrupts before the actual sending or receiving, then reenable
after the executions. It prevents the deadlocks because no process
switch happens during `call` or `receive.
