### PR TITLE
fix: `receive` did not handle sender pid queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "acpi",
  "aligned_ptr",
  "apic",
+ "arrayvec",
  "boot_info",
  "cc",
  "cfg_aliases",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -39,6 +39,7 @@ elfloader = "0.14.0"
 heapless = "0.7.5"
 rlibc = "1.0.0"
 ipc_api = { path = "../libs/ipc", package = "ipc" }
+arrayvec = { version = "0.7.1", default-features = false }
 
 [build-dependencies]
 cc = "1.0.70"

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -1,9 +1,9 @@
 use {
     crate::sysproc,
     aligned_ptr::slice,
+    arrayvec::ArrayVec,
     context::Context,
     core::{cell::UnsafeCell, convert::TryInto},
-    heapless::Deque,
     ipc_api::Message,
     os_units::NumOfPages,
     vm::{
@@ -46,7 +46,7 @@ pub(super) struct Process {
     context: UnsafeCell<Context>,
     priority: Priority,
     kernel_stack: Kbox<UnsafeCell<[u8; KERNEL_STACK_BYTES]>>,
-    sending_to_this: Deque<Pid, MAX_PROCESS>,
+    sending_to_this: ArrayVec<Pid, MAX_PROCESS>,
     state: State,
     message_buffer: Option<ReadWrite<Message>>,
 }
@@ -59,7 +59,7 @@ impl Process {
             context: UnsafeCell::default(),
             priority: Priority::new(LEAST_PRIORITY_LEVEL),
             kernel_stack: Self::generate_kernel_stack(),
-            sending_to_this: Deque::new(),
+            sending_to_this: ArrayVec::new(),
             state: State::Running,
             message_buffer: None,
         }
@@ -92,7 +92,7 @@ impl Process {
                     context,
                     priority: Priority::new(0),
                     kernel_stack,
-                    sending_to_this: Deque::new(),
+                    sending_to_this: ArrayVec::new(),
                     state: State::Runnable,
                     message_buffer: None,
                 })
@@ -136,7 +136,7 @@ impl Process {
                     context,
                     priority: Priority::new(0),
                     kernel_stack: Self::generate_kernel_stack(),
-                    sending_to_this: Deque::new(),
+                    sending_to_this: ArrayVec::new(),
                     state: State::Runnable,
                     message_buffer: None,
                 })


### PR DESCRIPTION
This commit fixes the problem of not modifying `sending_to_this`
correctly. The `receive` method popped an element from the queue when
the process specified `Any` for the sender but did nothing when the
process determined the sender's PID. This commit rewrote the code so
that `receive` always tries to pop a PID from the queue.
