### PR TITLE
chore: define `Pid` as a counterpart of `pid_t`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "posix"
+version = "0.1.0"
+
+[[package]]
 name = "predefined_mmap"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,9 @@ version = "0.1.0"
 [[package]]
 name = "ipc"
 version = "0.1.0"
+dependencies = [
+ "posix",
+]
 
 [[package]]
 name = "kernel"
@@ -265,6 +268,7 @@ dependencies = [
  "log",
  "os_units",
  "pic",
+ "posix",
  "predefined_mmap",
  "qemu",
  "qemu_print",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "libs/frame_allocator",
     "libs/ipc",
     "libs/pic",
+    "libs/posix",
     "libs/predefined_mmap",
     "libs/qemu",
     "libs/r_acpi",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -40,6 +40,7 @@ heapless = "0.7.5"
 rlibc = "1.0.0"
 ipc_api = { path = "../libs/ipc", package = "ipc" }
 arrayvec = { version = "0.7.1", default-features = false }
+posix = { path = "../libs/posix" }
 
 [build-dependencies]
 cc = "1.0.70"

--- a/kernel/src/process/manager.rs
+++ b/kernel/src/process/manager.rs
@@ -4,6 +4,7 @@ use {
         MAX_PROCESS,
     },
     crate::{interrupt, tss},
+    core::convert::TryInto,
     heapless::{Deque, Vec},
     ipc_api::Message,
     spinning_top::{const_spinlock, Spinlock, SpinlockGuard},
@@ -71,7 +72,7 @@ pub(super) fn add_idle() {
 }
 
 fn send_without_disabling_interrupts(to: Pid, mut message: Message) {
-    message.header.sender_pid = lock().running.as_usize();
+    message.header.sender_pid = lock().running.as_usize().try_into().unwrap();
 
     lock().send(to, message);
 

--- a/kernel/src/process/pid.rs
+++ b/kernel/src/process/pid.rs
@@ -1,8 +1,15 @@
 use {
     super::{manager, MAX_PROCESS},
-    core::fmt,
+    core::{
+        convert::{TryFrom, TryInto},
+        fmt,
+        num::TryFromIntError,
+    },
+    posix::sys::types::Pid as PosixPid,
 };
 
+// We use `usize` because it is more valuable than `PosixPid`. After all, we can use it as an index
+// of an array.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Pid(usize);
 impl Pid {
@@ -10,12 +17,12 @@ impl Pid {
         Self(pid)
     }
 
-    pub(super) fn generate() -> Option<Self> {
-        (0..MAX_PROCESS).find_map(|i| (!manager::process_exists(i.into())).then(|| Self(i)))
+    pub(super) const fn as_usize(self) -> usize {
+        self.0
     }
 
-    pub(super) fn as_usize(self) -> usize {
-        self.0
+    pub(super) fn generate() -> Option<Self> {
+        (0..MAX_PROCESS).find_map(|i| (!manager::process_exists(i.into())).then(|| Self(i)))
     }
 }
 impl From<Pid> for usize {
@@ -28,8 +35,24 @@ impl From<usize> for Pid {
         Pid(pid)
     }
 }
+impl TryFrom<PosixPid> for Pid {
+    type Error = NegativePid;
+
+    fn try_from(pid: PosixPid) -> Result<Self, Self::Error> {
+        pid.try_into().map(Self).map_err(|_| NegativePid(pid))
+    }
+}
+impl TryFrom<Pid> for PosixPid {
+    type Error = TryFromIntError;
+    fn try_from(pid: Pid) -> Result<Self, Self::Error> {
+        pid.as_usize().try_into()
+    }
+}
 impl fmt::Display for Pid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "PID {}", self.as_usize())
     }
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct NegativePid(PosixPid);

--- a/kernel/src/sysproc.rs
+++ b/kernel/src/sysproc.rs
@@ -1,6 +1,6 @@
 use {
     crate::process::ipc::{receive, send, ReceiveFrom},
-    core::mem::MaybeUninit,
+    core::{convert::TryInto, mem::MaybeUninit},
     ipc_api::message::{Body, Header, Message},
 };
 
@@ -19,8 +19,16 @@ pub(crate) fn main() -> ! {
                 body: Body(0x0114_0514, 0, 0, 0, 0),
             };
 
-            send(message.header.sender_pid.into(), reply);
-            log::info!("The sysproc sent a message.");
+            match message.header.sender_pid.try_into() {
+                Ok(pid) => {
+                    send(pid, reply);
+
+                    log::info!("The sysproc sent a message.");
+                }
+                Err(e) => {
+                    log::error!("The pid indicated an error: {:?}", e);
+                }
+            }
         }
     }
 }

--- a/libs/ipc/Cargo.toml
+++ b/libs/ipc/Cargo.toml
@@ -3,3 +3,6 @@ name = "ipc"
 version = "0.1.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
+
+[dependencies]
+posix = { path = "../posix" }

--- a/libs/ipc/src/message.rs
+++ b/libs/ipc/src/message.rs
@@ -1,3 +1,5 @@
+use posix::sys::types::Pid;
+
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Message {
@@ -8,7 +10,7 @@ pub struct Message {
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Header {
-    pub sender_pid: usize,
+    pub sender_pid: Pid,
 }
 
 #[repr(C)]

--- a/libs/posix/Cargo.toml
+++ b/libs/posix/Cargo.toml
@@ -2,7 +2,4 @@
 name = "posix"
 version = "0.1.0"
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+license = "MIT OR Apache-2.0"

--- a/libs/posix/Cargo.toml
+++ b/libs/posix/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "posix"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/libs/posix/src/lib.rs
+++ b/libs/posix/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/libs/posix/src/lib.rs
+++ b/libs/posix/src/lib.rs
@@ -1,7 +1,3 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+#![no_std]
+
+pub mod sys;

--- a/libs/posix/src/sys/mod.rs
+++ b/libs/posix/src/sys/mod.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/libs/posix/src/sys/types.rs
+++ b/libs/posix/src/sys/types.rs
@@ -1,0 +1,1 @@
+pub type Pid = i32;


### PR DESCRIPTION
- chore: add the `posix` crate
- chore: define `Pid` as the counterpart of `pid_t`
