### PR TITLE
fix: wrong stack pointer for the initial state

### DIFF
--- a/kernel/src/process/context.rs
+++ b/kernel/src/process/context.rs
@@ -81,6 +81,12 @@ impl Context {
         code_segment: SegmentSelector,
         data_segment: SegmentSelector,
     ) -> Self {
+        assert_eq!(
+            rsp.as_u64() % 16,
+            8,
+            "`RSP % 16` must be 8. We must simulate the condition after calling the main function."
+        );
+
         Self {
             rsp: rsp.as_u64(),
             rip: entry.as_u64(),

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -80,7 +80,7 @@ impl Process {
 
         let kernel_stack_len = kernel_stack.get_mut().len();
 
-        let kernel_stack_end = VirtAddr::from_ptr(kernel_stack.get()) + kernel_stack_len;
+        let kernel_stack_end = VirtAddr::from_ptr(kernel_stack.get()) + kernel_stack_len - 8_u64;
 
         unsafe {
             Self::switch_pml4_do(pml4, || {
@@ -128,7 +128,7 @@ impl Process {
 
                 let stack_range = vm::alloc_pages(stack_size, stack_flags)?;
 
-                let context = Context::user(entry, pml4, stack_range.end.start_address());
+                let context = Context::user(entry, pml4, stack_range.end.start_address() - 8_u64);
                 let context = UnsafeCell::new(context);
 
                 Some(Self {


### PR DESCRIPTION
We must simulate the situation where the main function is called. When a
function is called, `RSP % 16` is always 8.
