### PR TITLE
chore: define `try_send` and `try_receive`

### DIFF
--- a/libs/ipc/src/lib.rs
+++ b/libs/ipc/src/lib.rs
@@ -7,5 +7,5 @@ pub mod syscalls;
 pub use {
     error::Error,
     message::Message,
-    syscalls::{receive, send, ReceiveFrom},
+    syscalls::{try_receive, try_send, ReceiveFrom},
 };

--- a/libs/ipc/src/lib.rs
+++ b/libs/ipc/src/lib.rs
@@ -7,5 +7,5 @@ pub mod syscalls;
 pub use {
     error::Error,
     message::Message,
-    syscalls::{try_receive, try_send, ReceiveFrom},
+    syscalls::{receive, send, try_receive, try_send, ReceiveFrom},
 };

--- a/libs/ipc/src/syscalls.rs
+++ b/libs/ipc/src/syscalls.rs
@@ -39,6 +39,7 @@ pub fn try_send(to: Pid, message: Message) -> Result<(), Error> {
 /// # Panics
 ///
 /// This method panics if `from` specifies a negative PID.
+#[must_use]
 pub fn receive(from: ReceiveFrom) -> Message {
     try_receive(from).expect("Failed to receive a message.")
 }

--- a/libs/ipc/src/syscalls.rs
+++ b/libs/ipc/src/syscalls.rs
@@ -9,6 +9,13 @@ extern "sysv64" {
     fn execute_syscall(index: Ty, a1: u64, a2: u64) -> u64;
 }
 
+/// # Panics
+///
+/// This function panics if `to <= 0`.
+pub fn send(to: Pid, message: Message) {
+    try_send(to, message).expect("Failed to send a message.");
+}
+
 /// # Errors
 ///
 /// This function returns an error if there is no process with PID `to`.
@@ -27,6 +34,13 @@ pub fn try_send(to: Pid, message: Message) -> Result<(), Error> {
     } else {
         Err(Error)
     }
+}
+
+/// # Panics
+///
+/// This method panics if `from` specifies a negative PID.
+pub fn receive(from: ReceiveFrom) -> Message {
+    try_receive(from).expect("Failed to receive a message.")
 }
 
 /// # Errors

--- a/libs/ipc/src/syscalls.rs
+++ b/libs/ipc/src/syscalls.rs
@@ -16,7 +16,7 @@ extern "sysv64" {
 /// # Panics
 ///
 /// This function panics if `to <= 0`.
-pub fn send(to: Pid, message: Message) -> Result<(), Error> {
+pub fn try_send(to: Pid, message: Message) -> Result<(), Error> {
     let to = to.try_into();
     let to = to.expect("Invalid PID.");
 
@@ -36,7 +36,7 @@ pub fn send(to: Pid, message: Message) -> Result<(), Error> {
 /// # Panics
 ///
 /// This function panics if `from` specifies a negative PID.
-pub fn receive(from: ReceiveFrom) -> Result<Message, Error> {
+pub fn try_receive(from: ReceiveFrom) -> Result<Message, Error> {
     let mut m = MaybeUninit::uninit();
 
     let from = match from {

--- a/servers/init/src/main.rs
+++ b/servers/init/src/main.rs
@@ -16,9 +16,9 @@ fn main() -> ! {
             body: Body(0x334, 0, 0, 0, 0),
         };
 
-        ipc::try_send(2, message).unwrap();
+        ipc::send(2, message);
 
-        let message = ipc::try_receive(ReceiveFrom::Pid(2)).unwrap();
+        let message = ipc::receive(ReceiveFrom::Pid(2));
 
         assert_eq!(message.body, Body(0x0114_0514, 0, 0, 0, 0));
 

--- a/servers/init/src/main.rs
+++ b/servers/init/src/main.rs
@@ -16,12 +16,12 @@ fn main() -> ! {
             body: Body(0x334, 0, 0, 0, 0),
         };
 
-        ipc::send(2, message).unwrap();
+        ipc::try_send(2, message).unwrap();
 
-        let message = ipc::receive(ReceiveFrom::Pid(2)).unwrap();
+        let message = ipc::try_receive(ReceiveFrom::Pid(2)).unwrap();
 
         assert_eq!(message.body, Body(0x0114_0514, 0, 0, 0, 0));
 
-        assert!(ipc::receive(ReceiveFrom::Pid(6)).is_err());
+        assert!(ipc::try_receive(ReceiveFrom::Pid(6)).is_err());
     }
 }


### PR DESCRIPTION
- chore: rename to `try_(send|receive)`
- chore: redefine `send` and `receive`
