### PR TITLE
ci: only run on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   fmt:


### PR DESCRIPTION
Otherwise, Clippy workflow will fail because of the race condition.